### PR TITLE
ansible-controller: properly build and install captainhook

### DIFF
--- a/dockerfiles/dockerfile-ansible
+++ b/dockerfiles/dockerfile-ansible
@@ -15,6 +15,8 @@ RUN apk upgrade --no-cache --available && \
       && pip install --upgrade pip \
       && pip install boto \
       && go get github.com/bketelsen/captainhook \
+      && cp -f $GOPATH/bin/captainhook /usr/bin/ \
+      && rm -fr $GOPATH \
       && \
     :
 WORKDIR /opt/ansible

--- a/script/test_ansible.bats
+++ b/script/test_ansible.bats
@@ -23,3 +23,13 @@ load options
  run docker run --volumes-from playbooks-data -t -i --entrypoint bash autostager -c "pip list | grep autostager"
   [[ ${output} =~ autostager ]]
 }
+
+@test "ansible-controller: captainhook is in path" {
+ run docker run  -t -i --entrypoint bash ansible-security -c "command -v captainhook"
+ [[ ${output} =~ /usr/bin/captainhook ]]
+}
+
+@test "ansible-controller: captainhook is executable" {
+ run docker run  -t -i --entrypoint captainhook ansible-security --help
+ [[ ${output} =~ Usage ]]
+}


### PR DESCRIPTION
Ensure `captainhook` command can be executed from default PATH.
Add 2 new tests (for captainhook):

    user@devenv:~/ansible-security(hook*)$ make test
    bats script/test_*.bats
     ✓ ansible-controller: Ansible 2.x is installed
     ✓ ansible-controller: playbook fixtures directory is mounted
     ✓ ansible-controller: Go v1.6.x is installed
     ✓ autostager: latest version is installed
     ✓ ansible-controller: captainhook is in path
     ✓ ansible-controller: captainhook is executable

    6 tests, 0 failures

This also removes the dev cruft that builds up in GOPATH during build.