### PR TITLE
Autostager: Add required libraries

### DIFF
--- a/dockerfiles/dockerfile-autostager
+++ b/dockerfiles/dockerfile-autostager
@@ -4,7 +4,12 @@ MAINTAINER Tim Kropp @sometheycallme
 RUN apk upgrade --no-cache --available && \
     apk add --no-cache \
       python \
+      python-dev \
+      gcc \
       py-pip \
+      musl-dev \
+      libffi-dev \
+      openssl-dev \
       bash \
       git \
       && pip install --upgrade pip \


### PR DESCRIPTION
Libraries added: 
- `python-dev`
- `gcc`
- `musl-dev`
- `libffi-dev`
- `openssl-dev`