### PR TITLE
ansible-security: stop copying over fixtures into container

### DIFF
--- a/fixtures/Dockerfile
+++ b/fixtures/Dockerfile
@@ -1,4 +1,3 @@
 FROM scratch
-COPY /fixtures .
 VOLUME "/etc/ansible"
 VOLUME "/etc/captainhook"


### PR DESCRIPTION
to prepare for staged staged data in a PR that has playbook, we will remove fixtures from being copied over into the staging directory.

All we need is the directory structure 
