### PR TITLE
ansible-security: add cleanup docker script and modify circleCI test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,4 @@ runtime:
 
 .PHONY: test
 test:
-	docker rm -f playbooks-data &> /dev/null || :
-	docker rm -f hooktest &> /dev/null || :
-	docker create --name playbooks-data playbooks-data true
 	bats script/test_*.bats

--- a/helpful_files/cleanupdocker.sh
+++ b/helpful_files/cleanupdocker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -o errexit
+
+rmf="docker rm -f"
+rmi="docker rmi -f"
+
+echo "========================================="
+echo "autostager and ansible runnnin containers"
+echo "if there are no PIDS - it's cleaned "
+echo "========================================="
+as_containers=($(docker ps -a | grep autostager | awk '{print $1}'))
+ac_containers=($(docker ps -a | grep ansible | awk '{print $1'}))
+as_container_pids=" ${as_containers[*]} "
+ac_container_pids=" ${ac_containers[*]} "
+
+echo "====================================="
+echo "finding autostager and ansible images"
+echo "if there are no images - it's cleaned "
+echo "====================================="
+as_images=($(docker images | grep autostager | awk '{print $1}'))
+ac_images=($(docker images | grep ansible | awk '{print $1}'))
+as_image_ids=" ${as_images[*]} "
+ac_image_ids=" ${ac_images[*]} "
+
+echo "=================================="
+echo "containers that will be cleaned up"
+echo "=================================="
+echo $as_container_pids
+echo $ac_container_pids
+
+echo "=============================="
+echo "images that will be cleaned up"
+echo "=============================="
+echo $as_image_ids
+echo $ac_image_ids
+
+echo $as_container_pids | xargs -r $rmf
+echo $ac_container_pids | xargs -r $rmf
+echo $as_image_ids | xargs -r $rmi
+echo $ac_image_ids | xargs -r $rmi
+
+echo "==========================================="
+echo "Done: autostager and ansible docker cleaned"
+echo "==========================================="

--- a/script/build
+++ b/script/build
@@ -6,11 +6,11 @@ set -e
 options="--rm"
 echo $@ | grep '\--no-cache' &> /dev/null && options="$options --no-cache" || :
 
-echo "Building the Playbook Data image"
-docker build -f fixtures/Dockerfile -t ${DATA_IMAGE} .
+echo "Creating Staging Data volume"
+docker create -v /opt/staging --name ${DATA_IMAGE} alpine true
 
-echo "Building the Ansible Control image"
-docker build $options -f dockerfiles/dockerfile-ansible -t ${LOCAL_IMAGE} .
+echo "Building the Ansible Controller image"
+docker build $options -f dockerfiles/dockerfile-ansible -t ${CONTROLLER_IMAGE} .
 
 echo "Building the Autostager image"
 docker build $options -f dockerfiles/dockerfile-autostager -t ${AUTOSTAGER_IMAGE} .
@@ -25,5 +25,5 @@ echo "Show all docker images"
 docker images
 
 echo
-echo "WARN: you should docker tag the ansible control host image."
+echo "WARN: you should docker tag the images."
 echo

--- a/script/options.bash
+++ b/script/options.bash
@@ -6,7 +6,7 @@ else
   CAPS='--cap-drop all'
 fi
 
-DATA_IMAGE="playbooks-data:latest"
-LOCAL_IMAGE="ansible-security:latest"
+DATA_IMAGE="staging-data"
+CONTROLLER_IMAGE="ansible-controller:latest"
 AUTOSTAGER_IMAGE="autostager:latest"
 PUBLISHED_IMAGE="sometheycallme/ansible-controller:latest"

--- a/script/publish
+++ b/script/publish
@@ -4,6 +4,6 @@ set -e
 . script/options.bash
 
 docker login -e ${mail} -u ${user} -p ${pass}
-docker tag ${LOCAL_IMAGE} ${PUBLISHED_IMAGE}
+docker tag ${CONTROLLER_IMAGE} ${PUBLISHED_IMAGE}
 docker push ${PUBLISHED_IMAGE}
 docker logout

--- a/script/test
+++ b/script/test
@@ -3,13 +3,7 @@ set -ex -o pipefail
 . script/options.bash
 
 echo "Step1: Test for basic ansible install"
-docker run --volumes-from playbooks-data:latest -t -i --entrypoint bash ${LOCAL_IMAGE} -c "ls /opt/ansible" | grep ansible
+docker run --volumes-from ${DATA_IMAGE} -t -i --entrypoint bash ${CONTROLLER_IMAGE} -c "ls /opt/ansible" | grep ansible
 
 echo "Step2: Test for fixtures volume"
-docker run --volumes-from playbooks-data:latest -t -i --entrypoint bash ${LOCAL_IMAGE} -c "ls /etc/ansible" | grep test
-
-echo "Step3: Test for go"
-docker run --volumes-from playbooks-data:latest -t -i --entrypoint bash ${LOCAL_IMAGE} -c "ls ~/go"
-
-echo "Step 4: Test for 8080 listener"
-docker run --volumes-from playbooks-data:latest -t -i --entrypoint bash ${LOCAL_IMAGE} -c "netstat -an | grep 8080"
+docker run --volumes-from playbooks-data:latest -t -i --entrypoint bash ${CONTROLLER_IMAGE} -c "ls /opt" | grep staging

--- a/script/test_ansible.bats
+++ b/script/test_ansible.bats
@@ -5,16 +5,18 @@ load options
 # note: BATS does not respect this syntax: ${DATA_IMAGE}
 
 @test "ansible-controller: Ansible 2.x is installed" {
-  run docker run --volumes-from playbooks-data -t -i --entrypoint bash ansible-security -c "cd /opt/ansible; ansible --version"
+  run docker run --volumes-from $DATA_IMAGE -t -i --entrypoint bash $CONTROLLER_IMAGE -c "cd /opt/ansible; ansible --version"
   [[ ${output} =~ ansible\ 2\. ]]
 }
 
-@test "ansible-controller: playbook fixtures directory is mounted" {
- run docker run --volumes-from playbooks-data -t -i --entrypoint bash ansible-security -c "ls -l /etc/ansible"
-  [[ ${output} =~ total ]]
+docker run --volumes-from ansible-data:ro -p 8080:8080 -d ansible-controller
+
+@test "ansible-controller: staging directory is in path" {
+ run docker run --volumes-from $DATA_IMAGE -t -i --entrypoint bash $CONTROLLER_IMAGE -c "ls -l /opt | grep staging"
+  [[ ${output} =~ staging ]]
 }
 
-@test "autostager: latest version is installed" {
- run docker run --volumes-from playbooks-data -t -i --entrypoint bash autostager -c "pip list | grep autostager"
-  [[ ${output} =~ autostager ]]
+@test "autostager: autostager is in path" {
+ run docker run --volumes-from $DATA_IMAGE -t -i --entrypoint bash $AUTOSTAGER_IMAGE -c "ls -l /autostager"
+  [[ ${output} =~ autostager.py ]]
 }

--- a/script/test_ansible.bats
+++ b/script/test_ansible.bats
@@ -5,18 +5,16 @@ load options
 # note: BATS does not respect this syntax: ${DATA_IMAGE}
 
 @test "ansible-controller: Ansible 2.x is installed" {
-  run docker run --volumes-from $DATA_IMAGE -t -i --entrypoint bash $CONTROLLER_IMAGE -c "cd /opt/ansible; ansible --version"
+  run docker run --volumes-from $DATA_IMAGE:ro -t -i --entrypoint bash $CONTROLLER_IMAGE -c "cd /opt/ansible; ansible --version"
   [[ ${output} =~ ansible\ 2\. ]]
 }
 
-docker run --volumes-from ansible-data:ro -p 8080:8080 -d ansible-controller
-
 @test "ansible-controller: staging directory is in path" {
- run docker run --volumes-from $DATA_IMAGE -t -i --entrypoint bash $CONTROLLER_IMAGE -c "ls -l /opt | grep staging"
+ run docker run --volumes-from $DATA_IMAGE:ro -t -i --entrypoint bash $CONTROLLER_IMAGE -c "ls -l /opt | grep staging"
   [[ ${output} =~ staging ]]
 }
 
 @test "autostager: autostager is in path" {
- run docker run --volumes-from $DATA_IMAGE -t -i --entrypoint bash $AUTOSTAGER_IMAGE -c "ls -l /autostager"
+ run docker run --volumes-from $DATA_IMAGE:rw -t -i --entrypoint bash $AUTOSTAGER_IMAGE -c "ls -l /autostager"
   [[ ${output} =~ autostager.py ]]
 }

--- a/script/test_ansible.bats
+++ b/script/test_ansible.bats
@@ -16,5 +16,5 @@ load options
 
 @test "autostager: autostager is in path" {
  run docker run --volumes-from $DATA_IMAGE:rw -t -i --entrypoint bash $AUTOSTAGER_IMAGE -c "ls -l /autostager"
-  [[ ${output} =~ autostager.py ]]
+  [[ ${output} =~ autostager ]]
 }


### PR DESCRIPTION
before this commit: we need to cleanup containers manually

after this commit: we can run a script to cleanup ansible
and autostager pid's and images

note: doesn't handle the data image from alpine

extras: we fix associated circle tests following the initial commit