### PR TITLE
mock-client: add docker image for play.py exec

### DIFF
--- a/dockerfiles/dockerfile-ansible
+++ b/dockerfiles/dockerfile-ansible
@@ -17,6 +17,7 @@ RUN apk upgrade --no-cache --available && \
       && pip install --upgrade pip \
       && pip install boto \
       && pip install requests \
+      && pip install markupsafe \
       && \
     :
 WORKDIR /opt/ansible

--- a/dockerfiles/dockerfile-client
+++ b/dockerfiles/dockerfile-client
@@ -1,0 +1,21 @@
+FROM alpine:3.4
+MAINTAINER Tim Kropp @sometheycallme
+
+COPY /helpful_files /opt/client
+
+RUN apk upgrade --no-cache --available && \
+    apk add --no-cache \
+      python \
+      py-pip \
+      bash \
+      git \
+      curl \
+      && \
+    apk add --no-cache -X 'http://dl-cdn.alpinelinux.org/alpine/edge/main' \
+      'ansible>=2.0' \
+      && pip install --upgrade pip \
+      && pip install boto \
+      && pip install requests \
+      && \
+    :
+WORKDIR /opt/client

--- a/script/build
+++ b/script/build
@@ -18,11 +18,17 @@ docker build $options -f dockerfiles/dockerfile-ansible -t ${CONTROLLER_IMAGE} .
 echo "Building the Autostager image"
 docker build $options -f dockerfiles/dockerfile-autostager -t ${AUTOSTAGER_IMAGE} .
 
-echo "Show Ansible image sizes."
+echo "Building the mock client image"
+docker build $options -f dockerfiles/dockerfile-client -t ${CLIENT_IMAGE} .
+
+echo "Show Ansible image size."
 docker images | grep ansible-security | sort
 
-echo "Show Autostager image sizes."
+echo "Show Autostager image size."
 docker images | grep autostager | sort
+
+echo "Show Client image size."
+docker images | grep client | sort
 
 echo "Show all docker images"
 docker images

--- a/script/options.bash
+++ b/script/options.bash
@@ -6,6 +6,7 @@ else
   CAPS='--cap-drop all'
 fi
 
+CLIENT_IMAGE="client:latest"
 FIXTURES_DATA_IMAGE="fixtures-data"
 DATA_IMAGE="staging-data"
 CONTROLLER_IMAGE="ansible-controller:latest"

--- a/script/test_ansible.bats
+++ b/script/test_ansible.bats
@@ -20,7 +20,7 @@ load options
 }
 
 @test "ansible-controller: fixtures path is set for testing" {
- # check to see if the $FIXTURES_DATA_IMAGE is properly set iun path for controller to see playbook
+ # check to see if the $FIXTURES_DATA_IMAGE is properly set in path for controller to see playbook
  run docker run -i -t --name=voltest -p 8080:8080 --env-file helpful_files/env_vars -v /home/ubuntu/ansible-security/fixtures/etc/ansible:/opt/staging/cleanerbot_master/ansible-security --entrypoint bash ansible-controller -c "ls -l /opt/staging/cleanerbot_master/ansible-security"
  [[ ${output} =~ play_test.yml ]]
 }
@@ -42,4 +42,10 @@ load options
    echo $testoutput > testfile
   run grep PLAY testfile
  [[ ${output} =~ PLAY ]]
+}
+
+@test "mock-client: client play script is in path set for testing" {
+ # check to see if client side play.py script is in path 
+ run docker run -i -t --entrypoint bash $CLIENT_IMAGE -c "ls -l /opt/client"
+ [[ ${output} =~ play.py ]]
 }

--- a/script/test_ansible.bats
+++ b/script/test_ansible.bats
@@ -5,6 +5,7 @@ load options
 # note: BATS does not respect this syntax: ${DATA_IMAGE}
 
 @test "ansible-controller: Ansible 2.x is installed and running" {
+  sleep 3
   run docker run --volumes-from $DATA_IMAGE:ro -t -i --entrypoint bash $CONTROLLER_IMAGE -c "cd /opt/ansible; ansible --version"
   [[ ${output} =~ ansible\ 2\. ]]
 }


### PR DESCRIPTION
Prerequisite for #110 #109 need a client image to test from and the script inside of the container. 