### PR TITLE
wip: add gitlint to clientside docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,4 @@ runtime:
 .PHONY: test
 test: check
 	script/pylint
-	bats script/test_gitlint.bats
-	bats script/test_ansible.bats
+	bats script/test_*.bats

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,5 @@ runtime:
 .PHONY: test
 test: check
 	script/pylint
-	bats script/test_*.bats
+	bats script/test_gitlint.bats
+	bats script/test_ansible.bats

--- a/dockerfiles/dockerfile-client
+++ b/dockerfiles/dockerfile-client
@@ -10,7 +10,6 @@ RUN apk upgrade --no-cache --available && \
       bash \
       git \
       curl \
-      && \
       && git clone https://github.com/cleanerbot/ansible-security \
       && pip install --upgrade pip \
       && pip install boto \

--- a/dockerfiles/dockerfile-client
+++ b/dockerfiles/dockerfile-client
@@ -11,11 +11,13 @@ RUN apk upgrade --no-cache --available && \
       git \
       curl \
       && \
-    apk add --no-cache -X 'http://dl-cdn.alpinelinux.org/alpine/edge/main' \
-      'ansible>=2.0' \
+      && git clone https://github.com/cleanerbot/ansible-security \
       && pip install --upgrade pip \
       && pip install boto \
       && pip install requests \
+      && pip install gitlint \
       && \
     :
-WORKDIR /opt/client
+
+WORKDIR /ansible-security
+ENTRYPOINT ["gitlint"]

--- a/script/test_gitlint.bats
+++ b/script/test_gitlint.bats
@@ -1,0 +1,15 @@
+# vim: set ts=2 sw=2 ai et:
+
+load options
+
+# note: BATS does not respect this syntax: ${DATA_IMAGE}
+
+@test "gitlint: gitlint is in path and responds to commands" {
+ # test gitlint installation and response
+ run docker run -t -i --entrypoint bash $CLIENT_IMAGE -c "cd /ansible-security; gitlint --help"
+  [[ ${output} =~ Usage ]]
+}
+
+@test "gitlint: security conformity field checker is in place" {
+ # test gitlint against a commit with gitlint-hook
+}


### PR DESCRIPTION
This commit adds gitlint to the clientside docker image.
and also tests to see if it is in the path properly.

Before this commit: no capability to lint commit messages.

After this commit: gitlint is installed